### PR TITLE
Add the functionality to copy pads

### DIFF
--- a/classes/class.ilEtherpadLitePlugin.php
+++ b/classes/class.ilEtherpadLitePlugin.php
@@ -27,5 +27,18 @@ class ilEtherpadLitePlugin extends ilRepositoryObjectPlugin
 	{
 		return "EtherpadLite";
 	}
+
+	// fau: copyPad - new function allowCopy
+	/**
+	 * decides if this repository plugin can be copied
+	 *
+	 * @return bool
+	 */
+	public function allowCopy()
+	{
+		return true;
+	}
+	// fau.
+
 }
 ?>

--- a/classes/class.ilObjEtherpadLite.php
+++ b/classes/class.ilObjEtherpadLite.php
@@ -248,8 +248,35 @@ class ilObjEtherpadLite extends ilObjectPlugin
         }
         
     }
-	
-	/**
+    // fau: copyPad - new function doCloneObject
+    /**
+     * Do Cloning
+     * @var ilObjEtherpadLite $new_obj
+     * @var int $a_target_id
+     * @var int $a_copy_id
+     */
+    protected function doCloneObject($new_obj, $a_target_id, $a_copy_id = null)
+    {
+        $new_obj->setOnline($this->getOnline());
+        $new_obj->setShowControls($this->getShowControls());
+        $new_obj->setLineNumbers($this->getLineNumbers());
+        $new_obj->setShowColors($this->getShowColors());
+        $new_obj->setShowChat($this->getShowChat());
+        $new_obj->setMonospaceFont($this->getMonospaceFont());
+        $new_obj->setShowStyle($this->getShowStyle());
+        $new_obj->setShowList($this->getShowList());
+        $new_obj->setShowRedo($this->getShowRedo());
+        $new_obj->setShowColoring($this->GetShowColoring());
+        $new_obj->setShowHeading($this->getShowHeading());
+        $new_obj->setShowImportExport($this->getShowImportExport());
+        $new_obj->setShowTimeline($this->getShowTimeline());
+        $new_obj->setReadOnly($this->getReadOnly());
+        $new_obj->update();
+    }
+    // fau.
+
+
+    /**
      * Update data
      */
     protected function doUpdate()

--- a/classes/class.ilObjEtherpadLiteListGUI.php
+++ b/classes/class.ilObjEtherpadLiteListGUI.php
@@ -39,6 +39,9 @@ class ilObjEtherpadLiteListGUI extends ilObjectPluginListGUI
 	function initType()
 	{
 		$this->setType("xpdl");
+		// fau: copyPad - enable copy in list
+		$this->copy_enabled = true;
+		// fau.
 	}
 	
 	/**


### PR DESCRIPTION
With this extension, an etherpad object on ILIAS can be copied. In this case, the copy creates a new pad automatically.
@see https://docu.ilias.de/goto_docu_frm_2528_6820.html